### PR TITLE
Update Rule_03.txt

### DIFF
--- a/implementations/VTL/Rule_03.txt
+++ b/implementations/VTL/Rule_03.txt
@@ -1,9 +1,5 @@
-DS=id, level1,level2,level3 
+DS=level 
 
-DScalc:= DS[calc   1   as   "temp_id"   role   "identifier"]
-DStot:= DScalc [keep (temp_id,id)][aggregate count (id)]
-DSr:= DScalc[keep (temp_id,level1)][filter level1="high"][aggregate count(level1)]<(DStot*0.1) and
- DScalc[keep (temp_id,level2)][filter level2="high"][aggregate count(level2)]<(DStot*0.1)  and
- DScalc[keep (temp_id,level3)][filter level3="high"][aggregate count(level3)]<(DStot*0.1)
+DScalc:= DS[calc   1   as   "temp_id"   role   "identifier"", 1 as "msrcount" role "measure"]
 
-/* the Dataset must be checked in advance if there are NULL values in columns level1, level2 or level3 */
+DSr:= DScalc[filter level="high"][aggregate count(msrcount)]<=(( DScalc [aggregate count (msrcount)])*0.1) 


### PR DESCRIPTION
the rule has been modified taking into account:
- the dataset has only one column "level" compared to the prvious one having three columns "level1", "level2", "level3"
- the clarification about the NULL values
